### PR TITLE
show date posted instead of last modified in post metadata

### DIFF
--- a/layouts/partials/page_metadata.html
+++ b/layouts/partials/page_metadata.html
@@ -1,0 +1,70 @@
+{{ $is_list := .is_list }}
+{{ $share := .share | default false }}
+{{ $page := .page }}
+
+<meta content="{{ $page.Params.Date }}" itemprop="datePublished">
+<meta content="{{ $page.Params.LastMod }}" itemprop="dateModified">
+
+<div class="article-metadata">
+
+  {{/* If `authors` is set and is not empty. */}}
+  {{ if $page.Params.authors }}
+  {{ $authorLen := len $page.Params.authors }}
+  {{ if gt $authorLen 0 }}
+  <div>
+    {{ partial "page_metadata_authors" $page }}
+  </div>
+  {{ end }}
+  {{ end }}
+
+  {{ if not (in (slice "talk" "page") $page.Type) }}
+  <span class="article-date">
+    {{ $date := $page.Date.Format site.Params.date_format }}
+    {{ if eq $page.Type "publication" }}
+      {{ $date = $page.Date.Format (site.Params.publications.date_format | default "January, 2006") }}
+    {{ end }}
+    <time>{{ $date }}</time>
+  </span>
+  {{ end }}
+
+  {{ if and (eq $is_list 1) (eq $page.Type "publication") }}
+  <span class="middot-divider"></span>
+  <span class="pub-publication">
+    {{ if $page.Params.publication_short }}
+      {{ $page.Params.publication_short | markdownify }}
+    {{ else if $page.Params.publication }}
+      {{ $page.Params.publication | markdownify }}
+    {{ end }}
+  </span>
+  {{ end }}
+
+  {{ if and (eq $page.Type "post") (not (or (eq site.Params.reading_time false) (eq $page.Params.reading_time false))) }}
+  <span class="middot-divider"></span>
+  <span class="article-reading-time">
+    {{ $page.ReadingTime }} {{ i18n "minute_read" }}
+  </span>
+  {{ end }}
+
+  {{ $comments_enabled := and site.DisqusShortname (not (or site.Params.disable_comments (eq $page.Params.comments false))) }}
+  {{ if and $comments_enabled (site.Params.comment_count | default true) }}
+  <span class="middot-divider"></span>
+  <a href="{{ $page.RelPermalink }}#disqus_thread"><!-- Count will be inserted here --></a>
+  {{ end}}
+
+  {{ $taxonomy := "categories" }}
+  {{ with $page.Param $taxonomy }}
+  <span class="middot-divider"></span>
+  <span class="article-categories">
+    <i class="fas fa-folder"></i>
+    {{ range $index, $value := . -}}
+      {{- if gt $index 0 }}, {{ end -}}
+      <a href="{{ (site.GetPage (printf "/%s/%s" $taxonomy (. | urlize))).RelPermalink }}">{{ . }}</a>
+    {{- end -}}
+  </span>
+  {{ end }}
+
+  {{ if $share }}
+    {{ partial "share.html" $page }}
+  {{ end }}
+
+</div>


### PR DESCRIPTION
This PR shows you how to override the default academic theme page metadata layout. I hope this helps you see what to change (if you want to) to change the behavior of the page metadata. Site is looking good!!